### PR TITLE
Fixed a bug that blocked uglify

### DIFF
--- a/numeral-js.html
+++ b/numeral-js.html
@@ -121,7 +121,7 @@ Example:
         this._format();
       },
 
-      _format() {
+      _format: function () {
         if (this.format) {
           this._setOutput(numeral(this.number).format(this.format));
         } else {


### PR DESCRIPTION
You missed the notation of `functionName: function() {` on this one function.  I noticed it because when I ran polymer build on my project it was getting an error trying to uglify this file.

Thanks for writing this in the first place.